### PR TITLE
Move templates compiled files to a separate cache subfolder

### DIFF
--- a/upload/cache/views/.gitignore
+++ b/upload/cache/views/.gitignore
@@ -1,0 +1,3 @@
+*
+
+!.gitignore

--- a/upload/includes/classes/template.class.php
+++ b/upload/includes/classes/template.class.php
@@ -27,7 +27,7 @@ class CBTemplate {
         $Smarty->compile_check = true;
         $Smarty->debugging = false;
         $Smarty->template_dir = BASEDIR."/styles";
-        $Smarty->compile_dir  = BASEDIR."/cache";
+        $Smarty->compile_dir  = BASEDIR."/cache/views";
 
     }
 


### PR DESCRIPTION
I cloned the clipbucket project and when I checked git status, I found a lot of **untracked** files most of them are compiled files. In my opinion it is better to move them to a separate subfolder inside cache just like you are currently doing for **comments** and **userfeeds**. This makes the git status history clean and you can easily track the generation of new files especially when you are only using terminal.

After cloning and visiting few pages and I get this and I haven't even added a new file.
![The problem](http://i.imgur.com/TBu86lq.png)

Note: We can't really remove all untracked in one go as as `clipbucket.php` and `dbconnect.php` are generated during installation process, and they are required for the project working, so the best way to clean history as I mentioned before is to move them to separate folder and ignore the files of that folder.

I hope you accept pull requests and If possible can I get a link to contributing guidelines.
