### PR TITLE
Modify clean_var function in db_class.php to add some control on added fields

### DIFF
--- a/upload/includes/classes/db.class.php
+++ b/upload/includes/classes/db.class.php
@@ -454,8 +454,9 @@ class Clipbucket_db
      * @todo : Write method to clean stuff otherwise SQL injection is easily achievable
      */
     function clean_var($var)
-    {
-        return $var;
+    {	
+    	  $var=$this->mysqli->real_escape_string($var); //Simple mysql escape string. Probably not strong enough
+    	  return $var;
     }
 
     /**


### PR DESCRIPTION
The original clean_var was just a bypass waiting for a strong control of what is given to the db->insert and db->update functions. My modification is probably not strong enough but it removes some escape chars like ' wich can cause some dammage into the database. Simple try to edit video and add one ' in the description to see.
