### PR TITLE
Fix Can't extend error on php 7

### DIFF
--- a/upload/includes/classes/exceptions/db_exception.php
+++ b/upload/includes/classes/exceptions/db_exception.php
@@ -7,7 +7,7 @@
  * Making sense with error handling
  */
 
-class DB_Exception extends mysqli_sql_exception
+class DB_Exception
 {
 
     public function getError()


### PR DESCRIPTION
This fixes the can't extend error on php 7.
