### PR TITLE
Fix SQL injection & video edit table display

### DIFF
--- a/upload/admin_area/styles/cb_2014/layout/edit_video.html
+++ b/upload/admin_area/styles/cb_2014/layout/edit_video.html
@@ -153,7 +153,7 @@
         <div class="tab-content">
             <div id="videodetail" class="tab-pane active">
                 <div class="table table-responsive">
-                    <table class="myTable" width="600">
+                    <table class="myTable" width="100%">
                         <tr>
                             <td class="first"><label for="videoid">Video Id</label></td>
                             <td class="last">

--- a/upload/includes/classes/db.class.php
+++ b/upload/includes/classes/db.class.php
@@ -455,7 +455,7 @@ class Clipbucket_db
      */
     function clean_var($var)
     {
-        return $var;
+        return mysql_clean($var);
     }
 
     /**


### PR DESCRIPTION
- Video edit table display
  => When you're connected in admin area and editing a video widh a screen with of about 1266px, the video details table overflow on the video
- SQL injection
  => When you're connected in admin area and editing a video, try to type : "/!\ this is a test /!\" in comment (Not tested in tiltle or tags, but it must be the same) :+1: 
