### PR TITLE
Fix store_guest_session config

### DIFF
--- a/upload/cb_install/sql/configs.sql
+++ b/upload/cb_install/sql/configs.sql
@@ -221,7 +221,8 @@ INSERT INTO `{tbl_prefix}config` (`configid`, `name`, `value`) VALUES
 (221, 'collection_rating', '1'),
 (222, 'own_collection_rating', '1'),
 (223, 'own_video_rating', '1'),
-(224, 'vbrate_hd', '500000');
+(224, 'vbrate_hd', '500000'),
+(224, 'store_guest_session', 'no');
 
 
 

--- a/upload/cb_install/sql/upgrade_2.8.2.sql
+++ b/upload/cb_install/sql/upgrade_2.8.2.sql
@@ -1,0 +1,2 @@
+-- Addition for 2.8.2
+INSERT INTO `{tbl_prefix}config` (`configid`, `name`, `value`) VALUES  (224, 'store_guest_session', 'no');


### PR DESCRIPTION
The store_guest_session is not created when installing 2.8.1 and config keys aren't auto-generated when updating config from BO

Not sure about creating the "2.8.2" SQL upgrade file : if it's not the right way to do, just tell me !
