### PR TITLE
Modifiy nicetime function to avoid plural if term ending by s.

### DIFF
--- a/upload/includes/functions.php
+++ b/upload/includes/functions.php
@@ -2552,7 +2552,10 @@
 		$difference = round($difference);
 	   
 		if($difference != 1) {
-			$periods[$j].= "s";
+			// *** Dont apply plural if terms ending by a "s". Typically, french word for "month" is "mois".
+			if(substr($periods[$j], -1) != "s") {
+				$periods[$j].= "s";
+			}
 		}
 		return sprintf(lang($tense),$difference,$periods[$j]);
 	}


### PR DESCRIPTION
Hello, it's a small modification in order to avoid ending "s" when words already have. For example, french word "month" is "mois", the plural stay the same.
