### PR TITLE
Apply order by id to plugin load

### DIFF
--- a/upload/includes/classes/plugin.class.php
+++ b/upload/includes/classes/plugin.class.php
@@ -160,7 +160,7 @@ class CBPlugin extends ClipBucket
 			$active_query = " plugin_active='yes' ";
 		else
 			$active_query = NULL;
-		$results = $db->select(tbl("plugins"),"*",$active_query);
+		$results = $db->select(tbl("plugins"),"*",$active_query,false,"plugin_id");
 		
 		if(is_array($results))
 		foreach($results as $result)


### PR DESCRIPTION
Hello,
Load the plugins in the installation order. This is more convenient when a plugin needs another plugin to be loaded before.
