### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#ClipBucket - Broadcasting like a boss!
+# ClipBucket - Broadcasting like a boss!
 !['ClipBucket Screenshot'](http://clip-bucket.com/styles/default/images/laptop-large2.png)
 </br>
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
