### PR TITLE
Fixed invalid regex pattern in is_valid_email

### DIFF
--- a/upload/includes/functions.php
+++ b/upload/includes/functions.php
@@ -413,7 +413,7 @@
     */
 
     function is_valid_email($email) {
-	    $pattern = "/^([\w-\.]+@([\w-]+\.)+[\w-]{2,4})?$/";
+	    $pattern = "/^([\w\-\.]+@([\w\-]+\.)+[\w\-]{2,4})?$/";
 	    if(preg_match($pattern, $email)) {
 	        return true;
 	    } else {


### PR DESCRIPTION
A `-` needs to be escaped within a `[ ]` block or it will be interpreted as range