### PR TITLE
Fix typo

### DIFF
--- a/upload/cb_install/functions.php
+++ b/upload/cb_install/functions.php
@@ -128,7 +128,7 @@
 				if(!$version)
 					$return['err'] = _("Unable to find ffmpeg");
 				else
-					$return['msg'] = sprintf(_("Found FFMPEG %s : %s"),$version,$$ffmpeg_path);
+					$return['msg'] = sprintf(_("Found FFMPEG %s : %s"),$version,$ffmpeg_path);
 			}
 			break;
 			


### PR DESCRIPTION
There is a typo in the installer that causes it to show this:
![image](https://user-images.githubusercontent.com/63297273/164862940-c5f1779b-dfd3-4252-82cb-35e176d9ecff.png)

I fixed the typo.